### PR TITLE
add set datetime format %D{2006-01-02T15:04:05}

### DIFF
--- a/jsonconfig.go
+++ b/jsonconfig.go
@@ -3,9 +3,10 @@ package log4go
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/toolkits/file"
 	"os"
 	"strings"
+
+	"github.com/toolkits/file"
 )
 
 type ConsoleConfig struct {
@@ -176,11 +177,10 @@ func jsonToFileLogWriter(filename string, ff *FileConfig) (*FileLogWriter, bool)
 		return nil, true
 	}
 
-	flw := NewFileLogWriter(file, rotate)
+	flw := NewFileLogWriter(file, rotate, daily)
 	flw.SetFormat(format)
 	flw.SetRotateLines(maxlines)
 	flw.SetRotateSize(maxsize)
-	flw.SetRotateDaily(daily)
 	return flw, true
 }
 

--- a/log4go_test.go
+++ b/log4go_test.go
@@ -76,6 +76,38 @@ func TestFormatLogRecord(t *testing.T) {
 	}
 }
 
+var formatTestsDttmPattern = []struct {
+	Test    string
+	Record  *LogRecord
+	Formats map[string]string
+}{
+	{
+		Test: "Standard formats",
+		Record: &LogRecord{
+			Level:   ERROR,
+			Source:  "source",
+			Message: "message",
+			Created: now,
+		},
+		Formats: map[string]string{
+			"[%D{2006-01-02T15:04:05}] [%L] (%S) %M": "[2009-02-13T23:31:30] [EROR] (source) message\n",
+		},
+	},
+}
+
+func TestFormatDttmPatternLogRecord(t *testing.T) {
+	for _, test := range formatTestsDttmPattern {
+		name := test.Test
+		for fmt, want := range test.Formats {
+			if got := FormatLogRecord(fmt, test.Record); got != want {
+				t.Errorf("%s - %s:", name, fmt)
+				t.Errorf("   got %q", got)
+				t.Errorf("  want %q", want)
+			}
+		}
+	}
+}
+
 var logRecordWriteTests = []struct {
 	Test    string
 	Record  *LogRecord

--- a/xmlconfig.go
+++ b/xmlconfig.go
@@ -214,11 +214,10 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 		return nil, true
 	}
 
-	flw := NewFileLogWriter(file, rotate)
+	flw := NewFileLogWriter(file, rotate, daily)
 	flw.SetFormat(format)
 	flw.SetRotateLines(maxlines)
 	flw.SetRotateSize(maxsize)
-	flw.SetRotateDaily(daily)
 	return flw, true
 }
 
@@ -258,10 +257,9 @@ func xmlToXMLLogWriter(filename string, props []xmlProperty, enabled bool) (*Fil
 		return nil, true
 	}
 
-	xlw := NewXMLLogWriter(file, rotate)
+	xlw := NewXMLLogWriter(file, rotate, daily)
 	xlw.SetRotateLines(maxrecords)
 	xlw.SetRotateSize(maxsize)
-	xlw.SetRotateDaily(daily)
 	return xlw, true
 }
 


### PR DESCRIPTION

### Add custom datetime format function for pattern 

**Argument for datetime pattern**

>  stdLongMonth      = "January"
    stdMonth          = "Jan"
    stdNumMonth       = "1"
    stdZeroMonth      = "01"
    stdLongWeekDay    = "Monday"
    stdWeekDay        = "Mon"
    stdDay            = "2"
    stdUnderDay       = "_2"
    stdZeroDay        = "02"
    stdHour           = "15"
    stdHour12         = "3"
    stdZeroHour12     = "03"
    stdMinute         = "4"
    stdZeroMinute     = "04"
    stdSecond         = "5"
    stdZeroSecond     = "05"
    stdLongYear       = "2006"
    stdYear           = "06"
    stdPM             = "PM"
    stdpm             = "pm"
    stdTZ             = "MST"
    stdISO8601TZ      = "Z0700"  // prints Z for UTC
    stdISO8601ColonTZ = "Z07:00" // prints Z for UTC
    stdNumTZ          = "-0700"  // always numeric
    stdNumShortTZ     = "-07"    // always numeric
    stdNumColonTZ     = "-07:00" // always numeric



**Example**

1. `format : [%D{2006-01-02T15:04:05}] [%L] (%S) %M`
`Got : [2009-02-13T23:31:30] [EROR] (source) message`

2. `format : [%D{02-01-06T15:04:05}] [%L] (%S) %M`
`Got : [13-02-09T23:31:30] [EROR] (source) message`

3. `format : [%D{02.01.06T15:04:05}] [%L] (%S) %M`
`Got : [13.02.09T23:31:30] [EROR] (source) message`