### PR TITLE
Implemented newline encoding to defend against log injection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Here is a Json config example:
         "rotate": true,				// whether rotate the log
         "maxsize": "500M",
         "maxlines": "10K",
-        "daily": true
+        "daily": true,
+        "sanitize": true
     }], 
     "sockets": [{
         "enable": false,

--- a/examples/LogInjectionExample.go
+++ b/examples/LogInjectionExample.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+import l4g "log4go"
+
+const (
+	filename = "loginjection.log"
+)
+
+func main() {
+	var lineno int
+
+	user_input := []string{
+		"Knock knock",
+		"Who's there?",
+		"Orange",
+		"Orange who?",
+		"Orange you glad I\n[2001/01/01 01:23:45 EDT] [CRIT] (woot.woot:1337) The defendant is cleared of all wrongdoing.",
+	}
+
+	// Get a new logger instance
+	log := make(l4g.Logger)
+
+	/* Can also specify manually via the following: (these are the defaults) */
+	flw := l4g.NewFileLogWriter(filename, false, false)
+	flw.SetFormat("[%D %T] [%L] (%S) %M")
+	flw.SetRotate(false)
+	flw.SetRotateSize(0)
+	flw.SetRotateLines(0)
+	flw.SetRotateDaily(false)
+	flw.SetSanitize(true)
+	log.AddFilter("file", l4g.FINE, flw)
+
+	// Log some experimental messages
+	for _,message := range(user_input) {
+		log.Info(message)
+	}
+
+	//HACK. The system will lose the last few log messages due to a sync error. In this
+	//example program, there are only a  few messages, so it loses everything (at least
+	//on my system. This sleep preserves those messages.
+	time.Sleep(2 * time.Second)
+
+	// Close the log
+	log.Close()
+
+	// Print what was logged to the file 
+	fd, err := os.Open(filename)
+	if err != nil {
+		fmt.Printf("Error reopening file: %s", filename)
+		return
+	}
+
+	in := bufio.NewReader(fd)
+	fmt.Print("Messages logged to file were: (line numbers not included)\n")
+
+	for lineno = 1; ; lineno++ {
+		line, err := in.ReadString('\n')
+		if err == io.EOF {
+			lineno--
+			break
+		}
+		fmt.Printf("%3d:\t%s", lineno, line)
+	}
+	fd.Close()
+	// Remove the file so it's not lying around
+	os.Remove(filename)
+
+	if lineno != len(user_input) {
+		fmt.Fprintf(os.Stderr, "The user gave us %d lines of input but we logged %d. Hrmm...\n", len(user_input), lineno)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/jsonconfig.go
+++ b/jsonconfig.go
@@ -38,6 +38,7 @@ type FileConfig struct {
 	Maxsize  string `json:"maxsize"`  // \d+[KMG]? Suffixes are in terms of 2**10
 	Maxlines string `json:"maxlines"` //\d+[KMG]? Suffixes are in terms of thousands
 	Daily    bool   `json:"daily"`    //Automatically rotates by day
+	Sanitize bool	`json:"sanitize"` //Sanitize newlines to prevent log injection
 }
 
 type SocketConfig struct {
@@ -167,6 +168,7 @@ func jsonToFileLogWriter(filename string, ff *FileConfig) (*FileLogWriter, bool)
 	maxsize := 0
 	daily := false
 	rotate := false
+	sanitize := false
 
 	if len(ff.Filename) > 0 {
 		file = ff.Filename
@@ -182,6 +184,7 @@ func jsonToFileLogWriter(filename string, ff *FileConfig) (*FileLogWriter, bool)
 	}
 	daily = ff.Daily
 	rotate = ff.Rotate
+	sanitize = ff.Sanitize
 
 	if !ff.Enable {
 		return nil, true
@@ -191,6 +194,7 @@ func jsonToFileLogWriter(filename string, ff *FileConfig) (*FileLogWriter, bool)
 	flw.SetFormat(format)
 	flw.SetRotateLines(maxlines)
 	flw.SetRotateSize(maxsize)
+	flw.SetSanitize(sanitize)
 	return flw, true
 }
 

--- a/xmlconfig.go
+++ b/xmlconfig.go
@@ -182,6 +182,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 	maxsize := 0
 	daily := false
 	rotate := false
+	sanitize := false
 
 	// Parse properties
 	for _, prop := range props {
@@ -198,6 +199,8 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 			daily = strings.Trim(prop.Value, " \r\n") != "false"
 		case "rotate":
 			rotate = strings.Trim(prop.Value, " \r\n") != "false"
+		case "sanitize":
+			sanitize = strings.Trim(prop.Value, " \r\n") != "false"
 		default:
 			fmt.Fprintf(os.Stderr, "LoadConfiguration: Warning: Unknown property \"%s\" for file filter in %s\n", prop.Name, filename)
 		}
@@ -218,6 +221,7 @@ func xmlToFileLogWriter(filename string, props []xmlProperty, enabled bool) (*Fi
 	flw.SetFormat(format)
 	flw.SetRotateLines(maxlines)
 	flw.SetRotateSize(maxsize)
+	flw.SetSanitize(sanitize)
 	return flw, true
 }
 


### PR DESCRIPTION
Hi Jean,

This pull request implements newline encoding in the FileLogWriter to address an implicit log injection vulnerability. 

When a user of log4go logs data that is potentially attacker controlled (for instance, they log some oddly formatted form data found in a web request) they allow attackers to manipulate those application logs by injecting invalid log entries.

A description of log injection with examples can be found here: https://medium.com/@shatabda/security-log-injection-what-how-a510cfc0f73b. I've created a test program with a concrete example of how a log injection attack would work against log4go in the examples directory. Please look at examples/LogInjectionExample.go. 

A few design notes:
. Log injection can generally be defended against with input validation or output encoding. Output encoding is more flexible because it can be used to defend against arbitrary types of inputs. This fix uses output encoding, replacing newline characters ('\n') with string literals ('\' followed by 'n'.)
. Log injection can be fixed closer to the source of tainted data or closer to the output. Here I went with closer to the output. While newline characters are used in log4go to delimit log entries in text files, they are not necessarily used as such in other forms of logging such as socket logging. Perhaps in the future it will be wise to adapt this fix to be more flexible for different log destinations. 
. Because this fix changes potential output, I didn't want to make automatic newline encoding the default as a patch should never break compatibility if it can be avoided. As such, the ability to perform newline encoding is configuration driven and the default of this version is to not perform encoding. I suggest changing this in future major revisions of log4go.

Please feel free to reach out to me if you'd like to discuss these changes in greater detail. You can email me at werockthebodine@gmail.com.

Thanks!

Bodine Wilson