### PR TITLE
config console log to write to stderr

### DIFF
--- a/jsonconfig.go
+++ b/jsonconfig.go
@@ -14,6 +14,7 @@ type ConsoleConfig struct {
 	Enable  bool   `json:"enable"`
 	Level   string `json:"level"`
 	Pattern string `json:"pattern"`
+	Stderr  bool   `json:"stderr"`
 }
 
 type FileConfig struct {
@@ -38,7 +39,7 @@ type FileConfig struct {
 	Maxsize  string `json:"maxsize"`  // \d+[KMG]? Suffixes are in terms of 2**10
 	Maxlines string `json:"maxlines"` //\d+[KMG]? Suffixes are in terms of thousands
 	Daily    bool   `json:"daily"`    //Automatically rotates by day
-	Sanitize bool	`json:"sanitize"` //Sanitize newlines to prevent log injection
+	Sanitize bool   `json:"sanitize"` //Sanitize newlines to prevent log injection
 }
 
 type SocketConfig struct {
@@ -155,7 +156,7 @@ func jsonToConsoleLogWriter(filename string, cf *ConsoleConfig) (*ConsoleLogWrit
 		return nil, true
 	}
 
-	clw := NewConsoleLogWriter()
+	clw := NewConsoleLogWriter(cf.Stderr)
 	clw.SetFormat(format)
 
 	return clw, true

--- a/log4go.go
+++ b/log4go.go
@@ -149,7 +149,7 @@ func NewLogger() Logger {
 func NewConsoleLogger(lvl Level) Logger {
 	os.Stderr.WriteString("warning: use of deprecated NewConsoleLogger\n")
 	return Logger{
-		"stdout": &Filter{lvl, NewConsoleLogWriter(), "DEFAULT"},
+		"stdout": &Filter{lvl, NewConsoleLogWriter(false), "DEFAULT"},
 	}
 }
 
@@ -157,7 +157,7 @@ func NewConsoleLogger(lvl Level) Logger {
 // or above lvl to standard output.
 func NewDefaultLogger(lvl Level) Logger {
 	return Logger{
-		"stdout": &Filter{lvl, NewConsoleLogWriter(), "DEFAULT"},
+		"stdout": &Filter{lvl, NewConsoleLogWriter(false), "DEFAULT"},
 	}
 }
 

--- a/termlog.go
+++ b/termlog.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-var stdout io.Writer = os.Stdout
-
 // This is the standard writer that prints to standard output.
 type ConsoleLogWriter struct {
 	format string
@@ -18,12 +16,16 @@ type ConsoleLogWriter struct {
 }
 
 // This creates a new ConsoleLogWriter
-func NewConsoleLogWriter() *ConsoleLogWriter {
+func NewConsoleLogWriter(stderr bool) *ConsoleLogWriter {
 	consoleWriter := &ConsoleLogWriter{
 		format: "[%T %D] [%C] [%L] (%S) %M",
 		w:      make(chan *LogRecord, LogBufferLength),
 	}
-	go consoleWriter.run(stdout)
+	out := os.Stdout
+	if stderr {
+		out = os.Stderr
+	}
+	go consoleWriter.run(out)
 	return consoleWriter
 }
 func (c *ConsoleLogWriter) SetFormat(format string) {

--- a/xmlconfig.go
+++ b/xmlconfig.go
@@ -150,7 +150,7 @@ func xmlToConsoleLogWriter(filename string, props []xmlProperty, enabled bool) (
 		return nil, true
 	}
 
-	clw := NewConsoleLogWriter()
+	clw := NewConsoleLogWriter(false)
 	clw.SetFormat(format)
 
 	return clw, true


### PR DESCRIPTION
hi,   jeanphorn,   in my log4go project, i want to write some logs on the console, but also i want my project (a cli tool) 's output can be redirect by linux/mac pipe to other tools. E.g: `my-tool -f dot | dot -T png `. So the simple way is to config log4go console logger to write logs to stderr instead stdout, by json config right now. 

Thanks.